### PR TITLE
Fix using headline_block.tpl from a theme

### DIFF
--- a/class/headlinerenderer.php
+++ b/class/headlinerenderer.php
@@ -216,8 +216,7 @@ class XoopsHeadlineRenderer
                                    'site_url'  => $this->hl->getVar('headline_url'),
                                    'site_id'   => $this->hl->getVar('headline_id')
                                ));
-            $this->block = $this->tpl->fetch('file:' . XOOPS_ROOT_PATH
-                                             . '/modules/xoopsheadline/templates/blocks/headline_block.tpl');
+            $this->block = $this->tpl->fetch('db:blocks/headline_block.tpl');
             $retval      = true;
         }
 

--- a/xoops_version.php
+++ b/xoops_version.php
@@ -105,3 +105,5 @@ $modversion['templates'][1]['file']        = 'xoopsheadline_index.tpl';
 $modversion['templates'][1]['description'] = '';
 $modversion['templates'][2]['file']        = 'xoopsheadline_feed.tpl';
 $modversion['templates'][2]['description'] = '';
+$modversion['templates'][3]['file']        = 'blocks/headline_block.tpl';
+$modversion['templates'][3]['description'] = '';


### PR DESCRIPTION
The headline_block.tpl could not be used inside a them and change the content. With this patch this is able to be done.